### PR TITLE
Put dashboard under /api to make it available on production

### DIFF
--- a/lib/xrt_web/router.ex
+++ b/lib/xrt_web/router.ex
@@ -25,7 +25,7 @@ defmodule XrtWeb.Router do
   scope "/" do
     pipe_through [:browser, :admins_only]
 
-    live_dashboard "/dashboard"
+    live_dashboard "/api/dashboard"
   end
 
   forward "/api/graphiql", Absinthe.Plug.GraphiQL, schema: XrtWeb.Schema


### PR DESCRIPTION
Otherwise you'll just get a retro called `dashboard` 😅 Now the dashboard is accessible via `/api/dashboard`