### PR TITLE
Add stats query

### DIFF
--- a/lib/xrt/retros.ex
+++ b/lib/xrt/retros.ex
@@ -213,4 +213,9 @@ defmodule Xrt.Retros do
 
     @max_votes - Repo.one(query)
   end
+
+  @spec count() :: integer()
+  def count do
+    Repo.aggregate(Retro, :count)
+  end
 end

--- a/lib/xrt_web/resolvers/stats.ex
+++ b/lib/xrt_web/resolvers/stats.ex
@@ -1,0 +1,19 @@
+defmodule XrtWeb.Resolvers.Stats do
+  @moduledoc """
+  Resolver functions for statistics.
+  """
+
+  alias Xrt.Retros
+
+  @spec stats(any(), any(), any()) :: {:ok, map()}
+  def stats(_parent, _args, _context) do
+    {:ok,
+     %{
+       retros: retro_stats()
+     }}
+  end
+
+  defp retro_stats do
+    %{count: Retros.count()}
+  end
+end

--- a/lib/xrt_web/schema.ex
+++ b/lib/xrt_web/schema.ex
@@ -7,13 +7,16 @@ defmodule XrtWeb.Schema do
 
   import_types(XrtWeb.Types.User)
   import_types(XrtWeb.Types.Retro)
+  import_types(XrtWeb.Types.Stats)
 
   import_types(XrtWeb.Schemas.Queries.User)
   import_types(XrtWeb.Schemas.Queries.Retro)
+  import_types(XrtWeb.Schemas.Queries.Stats)
 
   query do
     import_fields(:user_queries)
     import_fields(:retro_queries)
+    import_fields(:stats_queries)
   end
 
   import_types(XrtWeb.Schemas.Mutations.Retro)

--- a/lib/xrt_web/schemas/queries/stats.ex
+++ b/lib/xrt_web/schemas/queries/stats.ex
@@ -1,0 +1,17 @@
+defmodule XrtWeb.Schemas.Queries.Stats do
+  @moduledoc """
+  Statistics related graphql queries.
+  """
+
+  use Absinthe.Schema.Notation
+
+  alias XrtWeb.Graphql.Errors
+  alias XrtWeb.Resolvers.Stats
+
+  object :stats_queries do
+    @desc "Get statistics"
+    field :stats, :stats do
+      resolve(Errors.handle_errors(&Stats.stats/3))
+    end
+  end
+end

--- a/lib/xrt_web/types/stats.ex
+++ b/lib/xrt_web/types/stats.ex
@@ -1,0 +1,15 @@
+defmodule XrtWeb.Types.Stats do
+  @moduledoc """
+  Statistics related graphql types.
+  """
+
+  use Absinthe.Schema.Notation
+
+  object :stats do
+    field :retros, non_null(:retro_stats)
+  end
+
+  object :retro_stats do
+    field :count, non_null(:integer)
+  end
+end

--- a/test/xrt_web/schemas/queries/stats_test.exs
+++ b/test/xrt_web/schemas/queries/stats_test.exs
@@ -1,0 +1,35 @@
+defmodule XrtWeb.Schemas.Queries.StatsTest do
+  use XrtWeb.GraphqlCase
+
+  import Xrt.Factory
+
+  describe "stats" do
+    @query """
+    query {
+      stats {
+        retros {
+          count
+        }
+      }
+    }
+    """
+    test "returns retro count" do
+      insert_list(4, :retro)
+
+      result =
+        build_conn()
+        |> run(@query)
+        |> query_result()
+
+      assert result == %{
+               "data" => %{
+                 "stats" => %{
+                   "retros" => %{
+                     "count" => 4
+                   }
+                 }
+               }
+             }
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/retro-tool/retro-tool/issues/24

I've discussed with @marciobarrios and for now we only need the retro count for the landing page.

Sample:

```gql
query {
  stats {
    retros {
      count
    }
  }
}
```