### PR TITLE
Add password support to retros

### DIFF
--- a/lib/xrt/retros.ex
+++ b/lib/xrt/retros.ex
@@ -21,13 +21,25 @@ defmodule Xrt.Retros do
     nil
   end
 
-  @spec find_retro(Retro.id() | Retro.slug()) :: Retro.t() | nil
   def find_retro(id) when is_integer(id) do
     Retro |> Repo.get(id)
   end
 
   def find_retro(slug) do
     Repo.get_by(Retro, slug: slug)
+  end
+
+  @spec correct_password?(Retro.t(), String.t()) :: boolean()
+  def correct_password?(%Retro{password_hash: nil}, _password) do
+    true
+  end
+
+  def correct_password?(%Retro{password_hash: _password_hash}, nil) do
+    false
+  end
+
+  def correct_password?(%Retro{password_hash: password_hash}, password) do
+    password_hash == Retro.encrypt_password(password)
   end
 
   @spec find_previous_retro(Retro.t()) :: Retro.t()

--- a/lib/xrt/retros.ex
+++ b/lib/xrt/retros.ex
@@ -99,6 +99,13 @@ defmodule Xrt.Retros do
     |> Repo.insert()
   end
 
+  @spec update(Retro.t(), map()) :: {:ok, Retro.t()} | {:error, any()}
+  def update(retro, input) do
+    retro
+    |> Retro.update_changeset(input)
+    |> Repo.update()
+  end
+
   @spec add_item(Retro.t(), map()) :: {:ok, RetroItem.t()} | {:error, any()}
   def add_item(retro, item_attrs) do
     attrs =

--- a/lib/xrt/retros.ex
+++ b/lib/xrt/retros.ex
@@ -52,14 +52,14 @@ defmodule Xrt.Retros do
     Repo.get_by(Retro, previous_retro_id: retro.id)
   end
 
-  @spec find_or_create_by_slug(Retro.slug() | nil, keyword()) ::
+  @spec find_or_create_by_slug(Retro.slug() | nil, map()) ::
           {:ok, Retro.t()} | {:error, any()}
-  def find_or_create_by_slug(slug, options \\ [])
+  def find_or_create_by_slug(slug, options \\ %{})
 
   def find_or_create_by_slug(nil, options) do
     slug =
       options
-      |> Keyword.get(:previous_retro_id)
+      |> Map.get(:previous_retro_id)
       |> find_retro()
       |> case do
         nil ->
@@ -89,10 +89,10 @@ defmodule Xrt.Retros do
     end
   end
 
-  @spec create(Retro.slug(), keyword()) :: {:ok, Retro.t()} | {:error, any()}
-  def create(slug, options \\ []) do
-    previous_retro_id = options |> Keyword.get(:previous_retro_id)
-    password = options |> Keyword.get(:password)
+  @spec create(Retro.slug(), map()) :: {:ok, Retro.t()} | {:error, any()}
+  def create(slug, options \\ %{}) do
+    previous_retro_id = options |> Map.get(:previous_retro_id)
+    password = options |> Map.get(:password)
 
     %Retro{}
     |> Retro.changeset(%{slug: slug, previous_retro_id: previous_retro_id, password: password})

--- a/lib/xrt/retros/retro.ex
+++ b/lib/xrt/retros/retro.ex
@@ -40,7 +40,14 @@ defmodule Xrt.Retros.Retro do
     |> Changeset.validate_required([:slug])
     |> Changeset.unique_constraint(:slug)
     |> Changeset.validate_length(:slug, min: 8, max: 64)
-    |> change_encrypt_password()
+    |> changeset_encrypt_password()
+  end
+
+  @spec update_changeset(t(), map()) :: Ecto.Changeset.t()
+  def update_changeset(struct, params) do
+    struct
+    |> Changeset.cast(params, [:password, :password_hash])
+    |> changeset_encrypt_password()
   end
 
   @spec encrypt_password(String.t()) :: binary()
@@ -48,14 +55,14 @@ defmodule Xrt.Retros.Retro do
     :crypto.hash(:sha256, password <> "SALT")
   end
 
-  defp change_encrypt_password(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+  defp changeset_encrypt_password(%Ecto.Changeset{valid?: false} = changeset), do: changeset
 
-  defp change_encrypt_password(%Ecto.Changeset{changes: %{password: password}} = changeset)
+  defp changeset_encrypt_password(%Ecto.Changeset{changes: %{password: password}} = changeset)
        when not is_nil(password) do
     encrypted_password = encrypt_password(password)
 
     Changeset.put_change(changeset, :password_hash, encrypted_password)
   end
 
-  defp change_encrypt_password(changeset), do: changeset
+  defp changeset_encrypt_password(changeset), do: changeset
 end

--- a/lib/xrt/retros/retro.ex
+++ b/lib/xrt/retros/retro.ex
@@ -11,18 +11,24 @@ defmodule Xrt.Retros.Retro do
           id: id() | nil,
           slug: slug() | nil,
           status: status() | nil,
-          previous_retro_id: id() | nil
+          previous_retro_id: id() | nil,
+          password: String.t() | nil,
+          password_hash: binary() | nil
         }
 
   use Ecto.Schema
-  import Ecto.Changeset
-  import EctoEnum
 
-  defenum(StatusEnum, :status, [:initial, :review, :actions, :final])
+  require EctoEnum
+
+  alias Ecto.Changeset
+
+  EctoEnum.defenum(StatusEnum, :status, [:initial, :review, :actions, :final])
 
   schema "retros" do
     field :slug, :string
     field :status, StatusEnum, default: :initial
+    field :password, :string, virtual: true
+    field :password_hash, :binary
     belongs_to :previous_retro, Xrt.Retros.Retro
     timestamps()
   end
@@ -30,9 +36,21 @@ defmodule Xrt.Retros.Retro do
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(struct, params \\ %{}) do
     struct
-    |> Ecto.Changeset.cast(params, [:slug, :status, :previous_retro_id])
-    |> validate_required([:slug])
-    |> unique_constraint(:slug)
-    |> validate_length(:slug, min: 8, max: 64)
+    |> Changeset.cast(params, [:slug, :status, :previous_retro_id, :password, :password_hash])
+    |> Changeset.validate_required([:slug])
+    |> Changeset.unique_constraint(:slug)
+    |> Changeset.validate_length(:slug, min: 8, max: 64)
+    |> encrypt_password()
   end
+
+  defp encrypt_password(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+
+  defp encrypt_password(%Ecto.Changeset{changes: %{password: password}} = changeset)
+       when not is_nil(password) do
+    encrypted_password = :crypto.hash(:sha256, password <> "SALT")
+
+    Changeset.put_change(changeset, :password_hash, encrypted_password)
+  end
+
+  defp encrypt_password(changeset), do: changeset
 end

--- a/lib/xrt/retros/retro.ex
+++ b/lib/xrt/retros/retro.ex
@@ -40,17 +40,22 @@ defmodule Xrt.Retros.Retro do
     |> Changeset.validate_required([:slug])
     |> Changeset.unique_constraint(:slug)
     |> Changeset.validate_length(:slug, min: 8, max: 64)
-    |> encrypt_password()
+    |> change_encrypt_password()
   end
 
-  defp encrypt_password(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+  @spec encrypt_password(String.t()) :: binary()
+  def encrypt_password(password) do
+    :crypto.hash(:sha256, password <> "SALT")
+  end
 
-  defp encrypt_password(%Ecto.Changeset{changes: %{password: password}} = changeset)
+  defp change_encrypt_password(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+
+  defp change_encrypt_password(%Ecto.Changeset{changes: %{password: password}} = changeset)
        when not is_nil(password) do
-    encrypted_password = :crypto.hash(:sha256, password <> "SALT")
+    encrypted_password = encrypt_password(password)
 
     Changeset.put_change(changeset, :password_hash, encrypted_password)
   end
 
-  defp encrypt_password(changeset), do: changeset
+  defp change_encrypt_password(changeset), do: changeset
 end

--- a/lib/xrt_web/resolvers/retros.ex
+++ b/lib/xrt_web/resolvers/retros.ex
@@ -27,7 +27,7 @@ defmodule XrtWeb.Resolvers.Retros do
         ) ::
           {:ok, Retro.t()} | {:error, any()}
   def find_retro(_parent, args, _resolution) do
-    {password, args} = Map.pop(args, :password, nil)
+    password = Map.get(args, :password, nil)
 
     args
     |> find_retro_from_args()
@@ -262,13 +262,8 @@ defmodule XrtWeb.Resolvers.Retros do
     end
   end
 
-  defp find_retro_from_args(%{slug: slug, previous_retro_id: previous_retro_id})
-       when not is_nil(previous_retro_id) do
-    Retros.find_or_create_by_slug(slug, previous_retro_id: previous_retro_id)
-  end
-
-  defp find_retro_from_args(%{slug: slug}) do
-    Retros.find_or_create_by_slug(slug)
+  defp find_retro_from_args(%{slug: slug} = args) do
+    Retros.find_or_create_by_slug(slug, args)
   end
 
   defp check_password({:ok, retro}, password) do

--- a/lib/xrt_web/resolvers/retros.ex
+++ b/lib/xrt_web/resolvers/retros.ex
@@ -30,7 +30,7 @@ defmodule XrtWeb.Resolvers.Retros do
     {password, args} = Map.pop(args, :password, nil)
 
     args
-    |> do_find_retro()
+    |> find_retro_from_args()
     |> check_password(password)
   end
 
@@ -40,7 +40,7 @@ defmodule XrtWeb.Resolvers.Retros do
     {password, args} = Map.pop(args, :password, nil)
 
     args
-    |> do_find_retro()
+    |> find_retro_from_args()
     |> check_password(password)
     |> case do
       {:ok, %Retro{} = retro} ->
@@ -251,7 +251,7 @@ defmodule XrtWeb.Resolvers.Retros do
     {password, args} = Map.pop(args, :password, nil)
 
     args
-    |> do_find_retro()
+    |> find_retro_from_args()
     |> check_password(password)
     |> case do
       {:ok, %Retro{slug: slug}} ->
@@ -262,12 +262,12 @@ defmodule XrtWeb.Resolvers.Retros do
     end
   end
 
-  defp do_find_retro(%{slug: slug, previous_retro_id: previous_retro_id})
+  defp find_retro_from_args(%{slug: slug, previous_retro_id: previous_retro_id})
        when not is_nil(previous_retro_id) do
     Retros.find_or_create_by_slug(slug, previous_retro_id: previous_retro_id)
   end
 
-  defp do_find_retro(%{slug: slug}) do
+  defp find_retro_from_args(%{slug: slug}) do
     Retros.find_or_create_by_slug(slug)
   end
 

--- a/lib/xrt_web/resolvers/retros.ex
+++ b/lib/xrt_web/resolvers/retros.ex
@@ -55,6 +55,23 @@ defmodule XrtWeb.Resolvers.Retros do
     result
   end
 
+  @spec update_retro(any(), %{slug: Retro.slug(), input: %{password: String.t()}}, any()) ::
+          {:ok, Retro.t()} | {:error, any()}
+  def update_retro(_parent, %{input: input} = args, _resolution) do
+    {password, args} = Map.pop(args, :password, nil)
+
+    args
+    |> do_find_retro()
+    |> check_password(password)
+    |> case do
+      {:ok, %Retro{} = retro} ->
+        Retros.update(retro, input)
+
+      result ->
+        result
+    end
+  end
+
   @spec find_previous_retro(Retro.t(), %{}, any()) :: {:ok, Retro.t() | nil}
   def find_previous_retro(parent, %{}, _resolution) do
     {:ok, Retros.find_previous_retro(parent)}

--- a/lib/xrt_web/schemas/mutations/retro.ex
+++ b/lib/xrt_web/schemas/mutations/retro.ex
@@ -9,6 +9,15 @@ defmodule XrtWeb.Schemas.Mutations.Retro do
   alias XrtWeb.Resolvers.Retros
 
   object :retro_mutations do
+    @desc "Update a retro"
+    field :update_retro, type: :retro do
+      arg(:slug, non_null(:string))
+      arg(:password, :string)
+      arg(:input, non_null(:update_retro_input))
+
+      resolve(Errors.handle_errors(&Retros.update_retro/3))
+    end
+
     @desc "Create a works type item"
     field :create_works_item, type: :retro_item do
       arg(:retro_slug, non_null(:string))

--- a/lib/xrt_web/schemas/queries/retro.ex
+++ b/lib/xrt_web/schemas/queries/retro.ex
@@ -13,6 +13,7 @@ defmodule XrtWeb.Schemas.Queries.Retro do
     field :retro, :retro do
       arg(:slug, :string)
       arg(:previous_retro_id, :integer)
+      arg(:password, :string)
 
       resolve(Errors.handle_errors(&Retros.find_retro/3))
     end

--- a/lib/xrt_web/schemas/subscriptions/retro.ex
+++ b/lib/xrt_web/schemas/subscriptions/retro.ex
@@ -10,10 +10,9 @@ defmodule XrtWeb.Schemas.Subscriptions.Retro do
   object :retro_subscriptions do
     field :retro_updated, :retro do
       arg(:slug, non_null(:string))
+      arg(:password, :string)
 
-      config(fn args, _ ->
-        {:ok, topic: args.slug}
-      end)
+      config(&Retros.subscribe_to_retro_updated/2)
 
       trigger(
         [

--- a/lib/xrt_web/types/retro.ex
+++ b/lib/xrt_web/types/retro.ex
@@ -43,6 +43,10 @@ defmodule XrtWeb.Types.Retro do
     end
   end
 
+  input_object :update_retro_input do
+    field :password, non_null(:string)
+  end
+
   object :retro_item do
     field :id, non_null(:id)
 

--- a/priv/repo/migrations/20200427184646_add_password_to_retros.exs
+++ b/priv/repo/migrations/20200427184646_add_password_to_retros.exs
@@ -1,0 +1,9 @@
+defmodule Xrt.Repo.Migrations.AddPasswordToRetros do
+  use Ecto.Migration
+
+  def change do
+    alter table("retros") do
+      add :password_hash, :binary
+    end
+  end
+end

--- a/test/support/graphql_case.ex
+++ b/test/support/graphql_case.ex
@@ -9,15 +9,7 @@ defmodule XrtWeb.GraphqlCase do
     quote do
       use XrtWeb.ConnCase
 
-      import Plug.Test
-
-      defp run(conn, query, variables \\ %{}) do
-        post(conn, "/api/graph", query: query, variables: variables)
-      end
-
-      defp query_result(conn) do
-        json_response(conn, 200)
-      end
+      import XrtWeb.GraphqlHelpers
     end
   end
 end

--- a/test/support/graphql_helpers.ex
+++ b/test/support/graphql_helpers.ex
@@ -1,0 +1,19 @@
+defmodule XrtWeb.GraphqlHelpers do
+  @moduledoc """
+  Helpers for Graphql related tests
+  """
+
+  use Phoenix.ConnTest
+
+  @endpoint XrtWeb.Endpoint
+
+  @spec run(Plug.Conn.t(), String.t(), map()) :: Plug.Conn.t()
+  def run(conn, query, variables \\ %{}) do
+    post(conn, "/api/graph", query: query, variables: variables)
+  end
+
+  @spec query_result(Plug.Conn.t()) :: map()
+  def query_result(conn) do
+    json_response(conn, 200)
+  end
+end

--- a/test/support/subscription_case.ex
+++ b/test/support/subscription_case.ex
@@ -1,0 +1,16 @@
+defmodule XrtWeb.SubscriptionCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  subscription tests.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with channels
+      use XrtWeb.ChannelCase
+      use Absinthe.Phoenix.SubscriptionTest, schema: XrtWeb.Schema
+    end
+  end
+end

--- a/test/xrt/retros_test.exs
+++ b/test/xrt/retros_test.exs
@@ -45,7 +45,7 @@ defmodule Xrt.RetrosTest do
         slug = "slug-#{password}"
 
         assert {:ok, %Retro{slug: ^slug, password_hash: password_hash}} =
-                 Retros.create(slug, password: password)
+                 Retros.create(slug, %{password: password})
 
         assert password_hash != nil
       end
@@ -53,13 +53,13 @@ defmodule Xrt.RetrosTest do
 
     property "doesn't create with password shorter than 8" do
       check all(password <- string(:alphanumeric, min_length: 0, max_length: 8)) do
-        assert {:error, _} = Retros.create("slug", password: password)
+        assert {:error, _} = Retros.create("slug", %{password: password})
       end
     end
 
     property "doesn't create with password longer than 32" do
       check all(password <- string(:alphanumeric, min_length: 32, max_length: 256)) do
-        assert {:error, _} = Retros.create("slug", password: password)
+        assert {:error, _} = Retros.create("slug", %{password: password})
       end
     end
   end
@@ -88,18 +88,17 @@ defmodule Xrt.RetrosTest do
       previous = insert(:retro, slug: "test-slug-1")
 
       assert {:ok, %Retro{slug: "test-slug-2"}} =
-               Retros.find_or_create_by_slug(nil, previous_retro_id: previous.id)
+               Retros.find_or_create_by_slug(nil, %{previous_retro_id: previous.id})
     end
 
-    @tag :focus
     test "creates based on the previous retro with password" do
       previous = insert(:retro, slug: "test-slug-1")
 
       assert {:ok, %Retro{slug: "test-slug-2", password_hash: password_hash}} =
-               Retros.find_or_create_by_slug(nil,
+               Retros.find_or_create_by_slug(nil, %{
                  previous_retro_id: previous.id,
                  password: "password"
-               )
+               })
 
       assert password_hash ==
                <<106, 89, 90, 204, 15, 70, 213, 177, 17, 227, 44, 209, 112, 120, 137, 178, 85,

--- a/test/xrt_web/schemas/queries/retro_test.exs
+++ b/test/xrt_web/schemas/queries/retro_test.exs
@@ -112,6 +112,15 @@ defmodule XrtWeb.Schemas.Queries.RetroTest do
       }
     """
 
+    test "it creates a retro with the password", %{conn: conn} do
+      conn
+      |> run(@query, %{slug: "super-slug", password: "new-password"})
+
+      retro = Xrt.Retros.find_retro("super-slug")
+
+      assert retro.password_hash != nil
+    end
+
     test "it returns the retro with the correct password", %{conn: conn} do
       retro = insert(:retro, password_hash: Retro.encrypt_password("super-secure-password"))
 

--- a/test/xrt_web/schemas/subscriptions/retro_test.exs
+++ b/test/xrt_web/schemas/subscriptions/retro_test.exs
@@ -1,0 +1,162 @@
+defmodule XrtWeb.Schemas.Subscriptions.RetroTest do
+  use XrtWeb.SubscriptionCase
+  use Phoenix.ConnTest
+
+  import Xrt.Factory
+  import XrtWeb.GraphqlHelpers
+
+  alias Xrt.Retros
+  alias Xrt.Retros.Retro
+
+  setup do
+    {:ok, socket} =
+      Phoenix.ChannelTest.connect(XrtWeb.UserSocket, %{
+        "user_uuid" => "user-uuid"
+      })
+
+    {:ok, socket} = join_absinthe(socket)
+
+    %{socket: socket}
+  end
+
+  @trigger """
+    mutation createWorksItem($slug: String!, $title: String!) {
+      createWorksItem(retro_slug: $slug, title: $title) {
+        id
+      }
+    }
+  """
+
+  defp add_item(retro) do
+    %{"data" => %{"createWorksItem" => %{"id" => item_id}}} =
+      build_conn()
+      |> run(@trigger, %{slug: retro.slug, title: "This works great"})
+      |> json_response(200)
+
+    item_id
+  end
+
+  describe "retroUpdated" do
+    @subscription """
+      subscription retroUpdated($slug: String!) {
+        retroUpdated(slug: $slug) {
+          slug
+          works {
+            id
+          }
+        }
+      }
+    """
+
+    setup do
+      %{retro: insert(:retro)}
+    end
+
+    test "pushes an update when a `works` item is added in the retro", %{
+      socket: socket,
+      retro: retro
+    } do
+      ref = push_doc(socket, @subscription, variables: %{slug: retro.slug})
+      assert_reply(ref, :ok, %{subscriptionId: subscription_id})
+
+      item_id = add_item(retro)
+      retro_slug = retro.slug
+
+      assert_push("subscription:data", %{
+        result: %{
+          data: %{
+            "retroUpdated" => %{
+              "slug" => ^retro_slug,
+              "works" => [%{"id" => ^item_id}]
+            }
+          }
+        }
+      })
+    end
+
+    test "doesn't push an update when a `works` item is added to another the retro", %{
+      socket: socket,
+      retro: retro
+    } do
+      other_retro = insert(:retro)
+      ref = push_doc(socket, @subscription, variables: %{slug: retro.slug})
+      assert_reply(ref, :ok, %{subscriptionId: subscription_id})
+
+      add_item(other_retro)
+
+      retro_slug = retro.slug
+
+      refute_push("subscription:data", %{
+        result: %{data: %{"retroUpdated" => %{"slug" => ^retro_slug}}}
+      })
+    end
+  end
+
+  describe "retroUpdated with password" do
+    @subscription """
+      subscription retroUpdated($slug: String!, $password: String) {
+        retroUpdated(slug: $slug, password: $password) {
+          slug
+          works {
+            id
+          }
+        }
+      }
+    """
+
+    setup do
+      %{retro: insert(:retro, password_hash: Retro.encrypt_password("password"))}
+    end
+
+    test "pushes an update when subscribing with the right password", %{
+      socket: socket,
+      retro: retro
+    } do
+      ref = push_doc(socket, @subscription, variables: %{slug: retro.slug, password: "password"})
+      assert_reply(ref, :ok, %{subscriptionId: subscription_id})
+
+      item_id = add_item(retro)
+
+      retro_slug = retro.slug
+
+      assert_push("subscription:data", %{
+        result: %{
+          data: %{
+            "retroUpdated" => %{"slug" => ^retro_slug, "works" => [%{"id" => ^item_id}]}
+          }
+        }
+      })
+    end
+
+    test "can't subscribe with the wrong password", %{socket: socket, retro: retro} do
+      ref =
+        push_doc(socket, @subscription, variables: %{slug: retro.slug, password: "wrong-password"})
+
+      assert_reply(ref, :error, %{
+        errors: [%{message: %{extensions: %{code: "UNAUTHORIZED"}}}]
+      })
+    end
+
+    test "receives an errored update when password changes after subscribing", %{
+      socket: socket,
+      retro: retro
+    } do
+      ref = push_doc(socket, @subscription, variables: %{slug: retro.slug, password: "password"})
+      assert_reply(ref, :ok, %{subscriptionId: subscription_id})
+
+      add_item(retro)
+      assert_push("subscription:data", %{})
+
+      Retros.update(retro, %{password: "new-password"})
+
+      add_item(retro)
+
+      assert_push("subscription:data", %{
+        result: %{
+          data: %{"retroUpdated" => nil},
+          errors: [%{extensions: %{code: "UNAUTHORIZED"}}]
+        }
+      })
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/retro-tool/retro-tool/issues/34

From now on, retros can be created/queried with a password:

```gql
retro(slug: "my-super-slug", password: "secure-password") {
  slug
  ...
}
```

(the password field is not mandatory, you can still use just `retro(slug: "my-super-slug)`)

with that query, there's three scenarios:
  - If the retro doesn't exist, it will be created and the password will be set
  - If the retro exists, it will only return it if the password matches
  - If the retro exists but the password doesn't match, it will return an error in the following format (following the [graphql spec for errors](https://spec.graphql.org/June2018/#sec-Errors):

```json
{
  "data": {
    "retro": null
  },
  "errors": [
    {
      "extensions": {
        "code": "UNAUTHORIZED",
        "context": []
      },
      "location": [{"column": 5, "line": 2}],
      "message": "This retro is protected by a password",
      "path": ["retro"]
    }
  ]
}
```

If the client queries a retro and receives this error in response, it means the user will have to be requested to enter a password.

--- 

For updating the password for an existing retro, this PR adds the `updateRetro` mutation:

```gql
updateRetro(slug: "my-super-slug", input: {password: "my-new-password}) {
  slug
  ...
}
```

in case the retro already has a password set, it will have to be sent too:

```gql
updateRetro(slug: "my-super-slug", password: "old-password", input: {password: "my-new-password}) {
  slug
  ...
}
```

if the password doesn't match, it won't allow updating and it will return the same `UNAUTHORIZED` error.

---

Regarding _subscriptions_, the behaviour is the same:

- When a retro doesn't have a password, the old format works just fine
- When a retro has a password, the password needs to be sent in the subscription:

```gql
subscription {
  retroUpdated(slug: "my-super-slug", password: "secure-password") {
    slug
    ...
  }
}
```

- if the password is not correct, the same `UNAUTHORIZED` error will be returned when attempting to subscribe.
- If a password is added (or the password changes) while the user is already subscribed successfully, the next update to that subscription will contain the `UNAUTHORIZED` error, meaning that the user needs to insert the new password and re-subscribe.