### PR TITLE
Remove votesLeft field from `user` type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run: mix ecto.migrate
       - run: mix credo
       - run:
-          command: MIX_ENV=dev mix dialyzer --plt
+          command: MIX_ENV=dev mix dialyzer
           no_output_timeout: 20m
       - run: mix test
       - save_cache:

--- a/lib/xrt/retros.ex
+++ b/lib/xrt/retros.ex
@@ -237,18 +237,6 @@ defmodule Xrt.Retros do
     StatusMachine.transition_to_next_step(retro)
   end
 
-  @spec votes_left_for(Retro.t(), String.t()) :: integer()
-  @max_votes 20
-  def votes_left_for(%Retro{id: retro_id}, user_uuid) do
-    query =
-      from v in RetroItemVote,
-        join: i in RetroItem,
-        where: i.id == v.retro_item_id and i.retro_id == ^retro_id and v.user_uuid == ^user_uuid,
-        select: count()
-
-    @max_votes - Repo.one(query)
-  end
-
   @spec count() :: integer()
   def count do
     Repo.aggregate(Retro, :count)

--- a/lib/xrt_web/resolvers/users.ex
+++ b/lib/xrt_web/resolvers/users.ex
@@ -3,46 +3,16 @@ defmodule XrtWeb.Resolvers.Users do
   Resolver functions for fields, queries and mutations related to users.
   """
 
-  alias Xrt.Retros
-  alias Xrt.Retros.{Retro, RetroItem, RetroItemVote}
-
   @typep context :: %{context: %{user_uuid: String.t()}}
 
-  @typep user :: %{
-           uuid: String.t(),
-           votes_left: integer()
-         }
+  @typep user :: %{uuid: String.t()}
 
-  @spec current_user(any(), %{retro_slug: Retro.slug()}, context()) :: {:ok, user()}
-  def current_user(_parent, %{retro_slug: slug}, %{context: %{user_uuid: user_uuid}}) do
-    retro = Retros.find_retro(slug)
-
-    {:ok, build_user(user_uuid, retro)}
+  @spec current_user(any(), %{}, context()) :: {:ok, user()}
+  def current_user(_parent, _params, %{context: %{user_uuid: user_uuid}}) do
+    {:ok, build_user(user_uuid)}
   end
 
-  @spec current_user_updated_trigger(%{retro_item_id: RetroItem.id(), user_uuid: String.t()}) ::
-          String.t()
-  def current_user_updated_trigger(%{retro_item_id: retro_item_id, user_uuid: user_uuid}) do
-    %RetroItem{retro_id: retro_id} = Xrt.Repo.get(RetroItem, retro_item_id)
-    retro = Xrt.Repo.get(Retro, retro_id)
-
-    "#{retro.slug}:#{user_uuid}"
-  end
-
-  @spec current_user_updated(RetroItemVote.t(), any(), context()) :: {:ok, user()}
-  def current_user_updated(%RetroItemVote{retro_item_id: retro_item_id}, _args, %{
-        context: %{user_uuid: user_uuid}
-      }) do
-    %RetroItem{retro_id: retro_id} = Xrt.Repo.get(RetroItem, retro_item_id)
-    retro = Xrt.Repo.get(Retro, retro_id)
-
-    {:ok, build_user(user_uuid, retro)}
-  end
-
-  defp build_user(user_uuid, retro) do
-    %{
-      uuid: user_uuid,
-      votes_left: Retros.votes_left_for(retro, user_uuid)
-    }
+  defp build_user(user_uuid) do
+    %{uuid: user_uuid}
   end
 end

--- a/lib/xrt_web/schemas/queries/user.ex
+++ b/lib/xrt_web/schemas/queries/user.ex
@@ -10,7 +10,7 @@ defmodule XrtWeb.Schemas.Queries.User do
   object :user_queries do
     @desc "Get the current user"
     field :current_user, :user do
-      arg(:retro_slug, non_null(:string))
+      arg(:retro_slug, :string)
 
       resolve(&Users.current_user/3)
     end

--- a/test/xrt/retros_test.exs
+++ b/test/xrt/retros_test.exs
@@ -337,34 +337,4 @@ defmodule Xrt.RetrosTest do
       assert actual == nil
     end
   end
-
-  describe "votes_left_for/2" do
-    @user_uuid "test_uuid"
-
-    setup do
-      retro = insert(:retro)
-
-      retro_item = insert(:retro_item, retro: retro)
-
-      {:ok, %{retro: retro, retro_item: retro_item}}
-    end
-
-    test "returns the remaining votes for the user", %{retro: retro, retro_item: retro_item} do
-      assert Retros.votes_left_for(retro, @user_uuid) == 20
-
-      insert(:retro_item_vote, retro_item: retro_item, user_uuid: @user_uuid)
-
-      assert Retros.votes_left_for(retro, @user_uuid) == 19
-
-      other_retro_item = insert(:retro_item, retro: retro)
-      insert(:retro_item_vote, retro_item: other_retro_item, user_uuid: @user_uuid)
-
-      assert Retros.votes_left_for(retro, @user_uuid) == 18
-
-      item_for_other_retro = insert(:retro_item)
-      insert(:retro_item_vote, retro_item: item_for_other_retro, user_uuid: @user_uuid)
-
-      assert Retros.votes_left_for(retro, @user_uuid) == 18
-    end
-  end
 end

--- a/test/xrt_web/schemas/queries/user_test.exs
+++ b/test/xrt_web/schemas/queries/user_test.exs
@@ -1,0 +1,55 @@
+defmodule XrtWeb.Schemas.Queries.UserTest do
+  use XrtWeb.GraphqlCase
+
+  describe "currentUser" do
+    @query """
+    query {
+      currentUser {
+        uuid
+      }
+    }
+    """
+
+    test "returns the uuid for the user" do
+      result =
+        build_conn()
+        |> run(@query)
+        |> query_result()
+
+      assert %{
+               "data" => %{
+                 "currentUser" => %{
+                   "uuid" => uuid
+                 }
+               }
+             } = result
+    end
+  end
+
+  describe "currentUser for slug (DEPRECATED)" do
+    @query """
+    query currentUser($slug: String) {
+      currentUser(retroSlug: $slug) {
+        uuid
+      }
+    }
+    """
+
+    test "returns the uuid for the user" do
+      result =
+        build_conn()
+        |> run(@query, %{slug: "non-existing-retro"})
+        |> query_result()
+
+      assert %{
+               "data" => %{
+                 "currentUser" => %{
+                   "uuid" => uuid
+                 }
+               }
+             } = result
+
+      assert uuid != nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/retro-tool/retro-tool/issues/44

This field wasn't used anyway, and it was causing an error.