### PR TITLE
Add step-specific transition mutations

### DIFF
--- a/lib/xrt/retros.ex
+++ b/lib/xrt/retros.ex
@@ -237,6 +237,17 @@ defmodule Xrt.Retros do
     StatusMachine.transition_to_next_step(retro)
   end
 
+  @spec transition_to_step(Retro.t(), atom()) :: {:ok, Retro.t()} | {:error, any()}
+  def transition_to_step(retro, step) do
+    case StatusMachine.find_next_step(retro) do
+      ^step ->
+        transition_to_next_step(retro)
+
+      _ ->
+        {:error, :forbidden}
+    end
+  end
+
   @spec count() :: integer()
   def count do
     Repo.aggregate(Retro, :count)

--- a/lib/xrt/retros/status_machine.ex
+++ b/lib/xrt/retros/status_machine.ex
@@ -26,7 +26,8 @@ defmodule Xrt.Retros.StatusMachine do
     end
   end
 
-  defp find_next_step(%Retro{status: status}) do
+  @spec find_next_step(Retro.t()) :: :review | :actions | :final | {:error, atom()}
+  def find_next_step(%Retro{status: status}) do
     Map.get(@status_transitions, status, {:error, status})
   end
 end

--- a/lib/xrt_web/resolvers/retros.ex
+++ b/lib/xrt_web/resolvers/retros.ex
@@ -197,6 +197,37 @@ defmodule XrtWeb.Resolvers.Retros do
     |> Retros.transition_to_next_step()
   end
 
+  @spec transition_to_review_step(any(), %{slug: Retro.slug()}, any()) ::
+          {:ok, Retro.t()} | {:error, any()}
+  def transition_to_review_step(_parent, %{slug: slug}, _) do
+    transition_to_step(slug, :review)
+  end
+
+  @spec transition_to_actions_step(any(), %{slug: Retro.slug()}, any()) ::
+          {:ok, Retro.t()} | {:error, any()}
+  def transition_to_actions_step(_parent, %{slug: slug}, _) do
+    transition_to_step(slug, :actions)
+  end
+
+  @spec transition_to_final_step(any(), %{slug: Retro.slug()}, any()) ::
+          {:ok, Retro.t()} | {:error, any()}
+  def transition_to_final_step(_parent, %{slug: slug}, _) do
+    transition_to_step(slug, :final)
+  end
+
+  defp transition_to_step(slug, step) do
+    slug
+    |> Retros.find_retro()
+    |> Retros.transition_to_step(step)
+    |> case do
+      {:ok, retro} ->
+        {:ok, retro}
+
+      {:error, :forbidden} ->
+        {:error, Errors.error(:forbidden, "This retro can't transition to that step")}
+    end
+  end
+
   @spec retro_updated_trigger(
           %{slug: Retro.slug()}
           | %{retro_item_id: RetroItem.id()}

--- a/lib/xrt_web/schemas/mutations/retro.ex
+++ b/lib/xrt_web/schemas/mutations/retro.ex
@@ -95,9 +95,32 @@ defmodule XrtWeb.Schemas.Mutations.Retro do
 
     @desc "Transitions retro to the next step"
     field :next_step, :retro do
+      deprecate("Use step-specific mutations instead")
+
       arg(:slug, non_null(:string))
 
       resolve(Errors.handle_errors(&Retros.next_step/3))
+    end
+
+    @desc "Transitions retro to the review step"
+    field :transition_to_review_step, :retro do
+      arg(:slug, non_null(:string))
+
+      resolve(Errors.handle_errors(&Retros.transition_to_review_step/3))
+    end
+
+    @desc "Transitions retro to the actions step"
+    field :transition_to_actions_step, :retro do
+      arg(:slug, non_null(:string))
+
+      resolve(Errors.handle_errors(&Retros.transition_to_actions_step/3))
+    end
+
+    @desc "Transitions retro to the final step"
+    field :transition_to_final_step, :retro do
+      arg(:slug, non_null(:string))
+
+      resolve(Errors.handle_errors(&Retros.transition_to_final_step/3))
     end
   end
 end


### PR DESCRIPTION
Implements the backend for https://github.com/retro-tool/retro-tool/issues/50

The new mutations look like this:

```gql
mutation transitionToReviewStep($slug: String!) {
  transitionToReviewStep(slug: $slug) {
    status
  }
}
```

```gql
mutation transitionToActionsStep($slug: String!) {
  transitionToFinalStep(slug: $slug) {
    status
  }
}
```

```gql
mutation transitionToFinalStep($slug: String!) {
  transitionToFinalStep(slug: $slug) {
    status
  }
}
```

When the requested step transition is not allowed for that retro, it will return a `FORBIDDEN` error:

```json
{
  "data": {},
  "errors": [
    {
      "extensions": {"code": "FORBIDDEN"}
    }
  ]
}
```